### PR TITLE
add datasets

### DIFF
--- a/Source/DatasetListGenerator/Stereo/gen_eth3d_stereo_list.py
+++ b/Source/DatasetListGenerator/Stereo/gen_eth3d_stereo_list.py
@@ -4,30 +4,30 @@ from ._meta_stereo_ops import MetaStereoOps
 
 
 class ETH3DStereoList(MetaStereoOps):
-    TRAIN_FOLDER_LIST = ['TRAIN/delivery_area_1l', 'TRAIN/delivery_area_1s',
-                         'TRAIN/delivery_area_2l', 'TRAIN/delivery_area_2s',
-                         'TRAIN/delivery_area_3l', 'TRAIN/delivery_area_3s',
-                         'TRAIN/electro_1l', 'TRAIN/electro_1s',
-                         'TRAIN/electro_2l', 'TRAIN/electro_2s',
-                         'TRAIN/electro_3l', 'TRAIN/electro_3s',
-                         'TRAIN/facade_1s', 'TRAIN/forest_1s',
-                         'TRAIN/forest_2s', 'TRAIN/playground_1l',
-                         'TRAIN/playground_1s', 'TRAIN/playground_2l',
-                         'TRAIN/playground_2s', 'TRAIN/playground_3l',
-                         'TRAIN/playground_3s', 'TRAIN/terrace_1s',
-                         'TRAIN/terrace_2s', 'TRAIN/terrains_1l',
-                         'TRAIN/terrains_1s', 'TRAIN/terrains_2l',
-                         'TRAIN/terrains_2s']
+    TRAIN_FOLDER_LIST = ['delivery_area_1l', 'delivery_area_1s',
+                         'delivery_area_2l', 'delivery_area_2s',
+                         'delivery_area_3l', 'delivery_area_3s',
+                         'electro_1l', 'electro_1s',
+                         'electro_2l', 'electro_2s',
+                         'electro_3l', 'electro_3s',
+                         'facade_1s', 'forest_1s',
+                         'forest_2s', 'playground_1l',
+                         'playground_1s', 'playground_2l',
+                         'playground_2s', 'playground_3l',
+                         'playground_3s', 'terrace_1s',
+                         'terrace_2s', 'terrains_1l',
+                         'terrains_1s', 'terrains_2l',
+                         'terrains_2s']
 
-    VAL_FOLDER_LIST = ['TEST/lakeside_1l', 'TEST/lakeside_1s', 'TEST/sand_box_1l',
-                       'TEST/sand_box_1s', 'TEST/storage_room_1l',
-                       'TEST/storage_room_1s', 'TEST/storage_room_2_1l',
-                       'TEST/storage_room_2_1s', 'TEST/storage_room_2_2l',
-                       'TEST/storage_room_2_2s', 'TEST/storage_room_2l',
-                       'TEST/storage_room_2s', 'TEST/storage_room_3l',
-                       'TEST/storage_room_3s', 'TEST/tunnel_1l',
-                       'TEST/tunnel_2l', 'TEST/tunnel_2s', 'TEST/tunnel_1s',
-                       'TEST/tunnel_3l', 'TEST/tunnel_3s']
+    VAL_FOLDER_LIST = ['lakeside_1l', 'lakeside_1s', 'sand_box_1l',
+                       'sand_box_1s', 'storage_room_1l',
+                       'storage_room_1s', 'storage_room_2_1l',
+                       'storage_room_2_1s', 'storage_room_2_2l',
+                       'storage_room_2_2s', 'storage_room_2l',
+                       'storage_room_2s', 'storage_room_3l',
+                       'storage_room_3s', 'tunnel_1l',
+                       'tunnel_2l', 'tunnel_2s', 'tunnel_1s',
+                       'tunnel_3l', 'tunnel_3s']
 
     def __init__(self, dataset_folder_path: str, save_folder_path: str) -> None:
         super().__init__(dataset_folder_path, save_folder_path)
@@ -38,9 +38,12 @@ class ETH3DStereoList(MetaStereoOps):
         file_num, off_set = 0, 1
         fd_file = self._open_file(os.path.join(self.save_folder_path, self._training_list))
         for folder_item in self.TRAIN_FOLDER_LIST:
-            left_img_path = os.path.join(self.dataset_folder_path, folder_item, 'im0.png')
-            right_img_path = os.path.join(self.dataset_folder_path, folder_item, 'im1.png')
-            disp_path = os.path.join(self.dataset_folder_path, folder_item, 'disp0GT.pfm')
+            left_img_path = os.path.join(
+                self.dataset_folder_path, 'two_view_training', folder_item, 'im0.png')
+            right_img_path = os.path.join(
+                self.dataset_folder_path, 'two_view_training', folder_item, 'im1.png')
+            disp_path = os.path.join(
+                self.dataset_folder_path, 'two_view_training_gt', folder_item, 'disp0GT.pfm')
             if not self._check_file_path(left_img_path, right_img_path, disp_path):
                 break
 
@@ -55,8 +58,10 @@ class ETH3DStereoList(MetaStereoOps):
         file_num, off_set = 0, 1
         fd_file = self._open_file(os.path.join(self.save_folder_path, self._testing_list))
         for folder_item in self.VAL_FOLDER_LIST:
-            left_img_path = os.path.join(self.dataset_folder_path, folder_item, 'im0.png')
-            right_img_path = os.path.join(self.dataset_folder_path, folder_item, 'im1.png')
+            left_img_path = os.path.join(
+                self.dataset_folder_path, 'two_view_test', folder_item, 'im0.png')
+            right_img_path = os.path.join(
+                self.dataset_folder_path, 'two_view_test', folder_item, 'im1.png')
             disp_path = None
 
             if not self._check_file_path(
@@ -68,7 +73,7 @@ class ETH3DStereoList(MetaStereoOps):
 
         self.close_file(fd_file)
         print('total file: ', file_num, '. The file has saved to ',
-              os.path.join(self.save_folder_path, self._training_list))
+              os.path.join(self.save_folder_path, self._testing_list))
 
     def exec(self) -> None:
         self._gen_training_list()

--- a/Source/DatasetListGenerator/Stereo/gen_middlebury_stereo_list.py
+++ b/Source/DatasetListGenerator/Stereo/gen_middlebury_stereo_list.py
@@ -16,19 +16,19 @@ class MiddleburyStereoList(MetaStereoOps):
 
     def __init__(self, dataset_folder_path: str, save_folder_path: str) -> None:
         super().__init__(dataset_folder_path, save_folder_path)
-        self._training_list = 'eth3d_stereo_training_list.csv'
-        self._testing_list = 'eth3d_stereo_testing_list.csv'
+        self._training_list = 'middlebury14_Q_stereo_training_list.csv'
+        self._testing_list = 'middlebury14_Q_stereo_testing_list.csv'
 
     def _gen_training_list(self) -> None:
         file_num, off_set = 0, 1
         fd_file = self._open_file(os.path.join(self.save_folder_path, self._training_list))
         for folder_item in self.TRAIN_FOLDER_LIST:
             left_img_path = os.path.join(
-                self.dataset_folder_path, 'trainingH/', folder_item, 'im0.png')
+                self.dataset_folder_path, 'trainingQ/', folder_item, 'im0.png')
             right_img_path = os.path.join(
-                self.dataset_folder_path, 'trainingH/', folder_item, 'im1.png')
+                self.dataset_folder_path, 'trainingQ/', folder_item, 'im1.png')
             disp_path = os.path.join(
-                self.dataset_folder_path, 'trainingH/', folder_item, 'disp0GT.pfm')
+                self.dataset_folder_path, 'trainingQ/', folder_item, 'disp0GT.pfm')
 
             if self._check_file_path(left_img_path, right_img_path, disp_path):
                 self.write_file(fd_file, f'{left_img_path},{right_img_path},{disp_path}')
@@ -45,8 +45,8 @@ class MiddleburyStereoList(MetaStereoOps):
         disp_path = 'None'
 
         for folder_item in self.VAL_FOLDER_LIST:
-            left_img_path = os.path.join(self.dataset_folder_path, 'testH/', folder_item, 'im0.png')
-            right_img_path = os.path.join(self.dataset_folder_path, 'testH/', folder_item, 'im1.png')
+            left_img_path = os.path.join(self.dataset_folder_path, 'testQ/', folder_item, 'im0.png')
+            right_img_path = os.path.join(self.dataset_folder_path, 'testQ/', folder_item, 'im1.png')
             if self._check_file_path(left_img_path, right_img_path, disp_path, is_training=False):
                 self.write_file(fd_file, f'{left_img_path},{right_img_path},{disp_path}')
             else:


### PR DESCRIPTION
## Summary by Sourcery

Enhance dataset list generation scripts by updating folder paths and output file names for ETH3D and Middlebury stereo datasets to improve organization and consistency.

Enhancements:
- Update folder paths in ETH3DStereoList to remove 'TRAIN/' and 'TEST/' prefixes for better organization.
- Modify path construction in ETH3DStereoList to include 'two_view_training' and 'two_view_training_gt' for training data, and 'two_view_test' for testing data.
- Change file path construction in MiddleburyStereoList to use 'trainingQ/' and 'testQ/' instead of 'trainingH/' and 'testH/'.
- Rename output CSV files in MiddleburyStereoList to 'middlebury14_Q_stereo_training_list.csv' and 'middlebury14_Q_stereo_testing_list.csv'.